### PR TITLE
feat: migrate SMS API from GET to POST with JSON body

### DIFF
--- a/csharp/send_single_message.cs
+++ b/csharp/send_single_message.cs
@@ -1,25 +1,36 @@
-string apiUrl = "<REPLACE_WITH_PROD_URL>/v1/messages/send";
-string from = "SMS INFO";
-string to = "22500000000000";
-string content = "Hello API!";
-string token = "<REPLACE_WITH_YOUR_API_KEY>";
-string dlrUrl = "https://mydomain.com:4444/dlr";
-string dlrMethod = "GET";
-string customData = "customData";
-string sendAt = "2023-02-13T21:40:00.000Z";
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
 
-var client = new RestClient(apiUrl);
-client.Timeout = -1;
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        string apiUrl = "<REPLACE_WITH_PROD_URL>/v1/messages/send";
+        string token = "<REPLACE_WITH_YOUR_API_KEY>";
 
-var request = new RestRequest(Method.GET);
-request.AddParameter("from", from);
-request.AddParameter("to", to);
-request.AddParameter("content", content);
-request.AddParameter("token", token);
-request.AddParameter("dlrUrl", dlrUrl);
-request.AddParameter("dlrMethod", dlrMethod);
-request.AddParameter("customData", customData);
-request.AddParameter("sendAt", sendAt);
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
-IRestResponse response = client.Execute(request);
-Console.WriteLine(response.Content);
+        var requestData = new
+        {
+            from = "SMS INFO",
+            to = "2250000000000",
+            content = "Hello API!",
+            dlrUrl = "https://mydomain.com:4444/dlr",
+            dlrMethod = "GET",
+            customData = "customData",
+            sendAt = "2023-02-13T21:40:00.000Z"
+        };
+
+        var json = JsonSerializer.Serialize(requestData);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await httpClient.PostAsync(apiUrl, content);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        Console.WriteLine(responseBody);
+    }
+}

--- a/java/send_single_message.java
+++ b/java/send_single_message.java
@@ -1,27 +1,37 @@
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import okhttp3.*;
 
 import java.io.IOException;
-import java.net.URLEncoder;
 
 public class Main {
     public static void main(String[] args) throws IOException {
         OkHttpClient client = new OkHttpClient().newBuilder().build();
         
-        String encodedURL = "<REPLACE_WITH_PROD_URL>/v1/messages/send?from=" +
-                URLEncoder.encode("SMS INFO", "UTF-8") +
-                "&to=2250000000000&content=Hello API!&token=<REPLACE_WITH_YOUR_API_KEY>&dlrUrl=" +
-                URLEncoder.encode("https://mydomain.com:4444/dlr", "UTF-8") +
-                "&dlrMethod=GET&customData=customData&sendAt=2023-02-13T21:40:00.000Z";
+        String prodUrl = "<REPLACE_WITH_PROD_URL>";
+        String token = "<REPLACE_WITH_YOUR_API_KEY>";
+        
+        MediaType mediaType = MediaType.parse("application/json");
+        String jsonBody = "{" +
+                "\"from\": \"SMS INFO\"," +
+                "\"to\": \"2250000000000\"," +
+                "\"content\": \"Hello API!\"," +
+                "\"dlrUrl\": \"https://mydomain.com:4444/dlr\"," +
+                "\"dlrMethod\": \"GET\"," +
+                "\"customData\": \"customData\"," +
+                "\"sendAt\": \"2023-02-13T21:40:00.000Z\"" +
+                "}";
+        
+        RequestBody body = RequestBody.create(jsonBody, mediaType);
         
         Request request = new Request.Builder()
-                .url(encodedURL)
-                .method("GET", null)
+                .url(prodUrl + "/v1/messages/send")
+                .method("POST", body)
+                .addHeader("Authorization", "Bearer " + token)
+                .addHeader("Content-Type", "application/json")
                 .build();
         
-        Response response = client.newCall(request).execute();
-        String responseBody = response.body().string();
-        System.out.println(responseBody);
+        try (Response response = client.newCall(request).execute()) {
+            String responseBody = response.body().string();
+            System.out.println(responseBody);
+        }
     }
 }

--- a/js/send_single_message.js
+++ b/js/send_single_message.js
@@ -1,22 +1,34 @@
 const prodUrl = "<REPLACE_WITH_PROD_URL>"
 const token = "<REPLACE_WITH_YOUR_API_KEY>"
 
-const url = encodeURI(
-  `${prodUrl}/v1/messages/send?from=SMS INFO&to=2250000000000&content=Hello API!&token=${token}&dlrUrl=https://mydomain.com:4444/dlr&dlrMethod=GET&customData=customData&sendAt=2023-02-13T21:40:00.000Z`,
-)
-
-const fetchData = async () => {
+const sendMessage = async () => {
   try {
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {},
+    const data = JSON.stringify({
+      from: "SMS INFO",
+      to: "2250000000000",
+      content: "Hello API!",
+      dlrUrl: "https://mydomain.com:4444/dlr",
+      dlrMethod: "GET",
+      customData: "customData",
+      sendAt: "2023-02-13T21:40:00.000Z",
     })
 
-    const data = await response.json()
-    console.log(JSON.stringify(data))
+    const url = `${prodUrl}/v1/messages/send`
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: data,
+    })
+
+    const responseData = await response.json()
+    console.log(JSON.stringify(responseData))
   } catch (error) {
     console.log(error)
   }
 }
 
-fetchData()
+sendMessage()

--- a/php/curl/send_single_message.php
+++ b/php/curl/send_single_message.php
@@ -1,40 +1,41 @@
 <?php
-// Replace the following values with your own
 $prodUrl = '<REPLACE_WITH_PROD_URL>';
 $token = '<YOUR_TOKEN>';
-$from = 'SMS INFO';
-$to = '2250000000000';
-$content = 'Hello API!';
-$dlrUrl = 'https://mydomain.com:4444/dlr';
-$customData = 'customData';
-$sendAt = '2023-02-13T21:40:00.000Z';
 
-$headers = [
-    'Authorization: Bearer ' . $token,
-    'Content-Type: application/json'
+$data = [
+    'from' => 'SMS INFO',
+    'to' => '2250000000000',
+    'content' => 'Hello API!',
+    'dlrUrl' => 'https://mydomain.com:4444/dlr',
+    'dlrMethod' => 'GET',
+    'customData' => 'customData',
+    'sendAt' => '2023-02-13T21:40:00.000Z'
 ];
 
-$url = $prodUrl . '/v1/messages/send?from=' . urlencode($from) .
-       '&to=' . $to .
-       '&content=' . urlencode($content) .
-       '&token=' . $token .
-       '&dlrUrl=' . urlencode($dlrUrl) .
-       '&dlrMethod=GET&customData=' . $customData .
-       '&sendAt=' . urlencode($sendAt);
+$ch = curl_init($prodUrl . '/v1/messages/send');
 
-$ch = curl_init($url);
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => [
+        'Authorization: Bearer ' . $token,
+        'Content-Type: application/json'
+    ],
+    CURLOPT_POSTFIELDS => json_encode($data)
+]);
 
 $response = curl_exec($ch);
 
-if($response === false)
-{
-    echo 'Curl error: ' . curl_error($ch);
-}
-else
-{
-    echo $response;
+if(curl_errno($ch)) {
+    echo 'Erreur cURL : ' . curl_error($ch);
+} else {
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    if($httpCode >= 400) {
+        echo "Erreur HTTP $httpCode : " . $response;
+    } else {
+        echo $response;
+    }
 }
 
 curl_close($ch);
+?>

--- a/php/guzzle/send_single_message.php
+++ b/php/guzzle/send_single_message.php
@@ -1,28 +1,38 @@
 <?php
-// GUZZLE
-// Make sure to install Guzzle using Composer: composer require guzzlehttp/guzzle
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 
-// Replace the following values with your own
 $prodUrl = '<REPLACE_WITH_PROD_URL>';
 $token = '<YOUR_TOKEN>';
-$from = 'SMS INFO';
-$to = '2250000000000';
-$content = 'Hello API!';
-$dlrUrl = 'https://mydomain.com:4444/dlr';
-$customData = 'customData';
-$sendAt = '2023-02-13T21:40:00.000Z';
 
-$client = new Client();
+$data = [
+    'from' => 'SMS INFO',
+    'to' => '2250000000000',
+    'content' => 'Hello API!',
+    'dlrUrl' => 'https://mydomain.com:4444/dlr',
+    'dlrMethod' => 'GET',
+    'customData' => 'customData',
+    'sendAt' => '2023-02-13T21:40:00.000Z'
+];
 
-$url = $prodUrl . '/v1/messages/send?from=' . urlencode($from) .
-    '&to=' . $to . '&content=' . urlencode($content) .
-    '&token=' . $token . '&dlrUrl=' . urlencode($dlrUrl) .
-    '&dlrMethod=GET&customData=' . $customData .
-    '&sendAt=' . urlencode($sendAt);
+$client = new Client([
+    'headers' => [
+        'Authorization' => 'Bearer ' . $token,
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json'
+    ]
+]);
 
-$request = new Request('GET', $url);
-$res = $client->sendAsync($request)->wait();
-echo $res->getBody();
+try {
+    $response = $client->post($prodUrl . '/v1/messages/send', [
+        'json' => $data
+    ]);
+    
+    echo $response->getBody();
+} catch (\GuzzleHttp\Exception\RequestException $e) {
+    echo 'Error: ' . $e->getMessage();
+    if ($e->hasResponse()) {
+        echo ' - ' . $e->getResponse()->getBody();
+    }
+}

--- a/postman/LeTexto Client API.postman_collection.json
+++ b/postman/LeTexto Client API.postman_collection.json
@@ -9,46 +9,33 @@
     {
       "name": "Send single Message",
       "request": {
-        "method": "GET",
-        "header": [],
-        "url": {
-          "raw": "https://apis.letexto.com/v1/messages/send?from=SMS INFO&to=2250000000000&content=Hello API!&token=a12yhu5847ejuell458222ed&dlrUrl=https://mydomain.com:4444/dlr&dlrMethod=GET&customData=customData&sendAt=2023-02-13T21:40:00.000Z",
-          "protocol": "https",
-          "path": ["v1", "messages", "send"],
-          "query": [
-            {
-              "key": "from",
-              "value": "SMS INFO"
-            },
-            {
-              "key": "to",
-              "value": "2250000000000"
-            },
-            {
-              "key": "content",
-              "value": "Hello API!"
-            },
-            {
-              "key": "token",
-              "value": "a12yhu5847ejuell458222ed"
-            },
-            {
-              "key": "dlrUrl",
-              "value": "https://mydomain.com:4444/dlr"
-            },
-            {
-              "key": "dlrMethod",
-              "value": "GET"
-            },
-            {
-              "key": "customData",
-              "value": "customData"
-            },
-            {
-              "key": "sendAt",
-              "value": "2023-02-13T21:40:00.000Z"
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer a12yhu5847ejuell458222ed",
+            "type": "text"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"from\": \"SMS INFO\",\n  \"to\": \"2250000000000\",\n  \"content\": \"Hello API!\",\n  \"dlrUrl\": \"https://mydomain.com:4444/dlr\",\n  \"dlrMethod\": \"GET\",\n  \"customData\": \"customData\",\n  \"sendAt\": \"2023-02-13T21:40:00.000Z\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
             }
-          ]
+          }
+        },
+        "url": {
+          "raw": "https://apis.letexto.com/v1/messages/send",
+          "protocol": "https",
+          "host": ["apis", "letexto", "com"],
+          "path": ["v1", "messages", "send"]
         }
       },
       "response": []

--- a/python/send_single_message.py
+++ b/python/send_single_message.py
@@ -1,8 +1,22 @@
 import requests
 
-url = "<REPLACE_WITH_PROD_URL>/v1/messages/send?from=SMS%20INFO&to=225058743342&content=Hello%20API!&token=<REPLACE_WITH_YOUR_API_KEY>&dlrUrl=https://mydomain.com:4444/dlr&dlrMethod=GET&customData=customData&sendAt=2023-02-13T21:40:00.000Z"
-headers = {}
+url = "<REPLACE_WITH_PROD_URL>/v1/messages/send"
+token = "<REPLACE_WITH_YOUR_API_KEY>"
 
-response = requests.get(url, headers=headers)
-data = response.content.decode("utf-8")
-print(data)
+response = requests.post(
+    url,
+    headers={
+        "Authorization": f"Bearer {token}"
+    },
+    json={
+        "from": "SMS INFO",
+        "to": "225058743342",
+        "content": "Hello API!",
+        "dlrUrl": "https://mydomain.com:4444/dlr",
+        "dlrMethod": "GET",
+        "customData": "customData",
+        "sendAt": "2023-02-13T21:40:00.000Z"
+    }
+)
+
+print(response.text)

--- a/vb.net/send_single_message.vb
+++ b/vb.net/send_single_message.vb
@@ -1,8 +1,36 @@
-Dim url As String = "<REPLACE_WITH_URL_PROD>/v1/messages/send?from=" + Uri.EscapeDataString("SMS INFO") + "&to=2250000000000&content=Hello API!&token=<REPLACE_WITH_YOUR_API_KEY>&dlrUrl=" + Uri.EscapeDataString("https://mydomain.com:4444/dlr") + "&dlrMethod=GET&customData=customData&sendAt=2023-02-13T21:40:00.000Z"
-Dim client As New RestClient(url)
-client.Timeout = -1
+Imports System.Net.Http
+Imports System.Text
+Imports System.Text.Json
 
-Dim request As New RestRequest(Method.GET)
-Dim response As IRestResponse = client.Execute(request)
+Module Module1
+    Async Function SendSms() As Task
+        Dim apiUrl As String = "<REPLACE_WITH_PROD_URL>/v1/messages/send"
+        Dim token As String = "<REPLACE_WITH_YOUR_API_KEY>"
 
-Console.WriteLine(response.Content)
+        Using httpClient As New HttpClient()
+            httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}")
+
+            Dim requestData = New With {
+                .from = "SMS INFO",
+                .to = "2250000000000",
+                .content = "Hello API!",
+                .dlrUrl = "https://mydomain.com:4444/dlr",
+                .dlrMethod = "GET",
+                .customData = "customData",
+                .sendAt = "2023-02-13T21:40:00.000Z"
+            }
+
+            Dim json As String = JsonSerializer.Serialize(requestData)
+            Dim content As New StringContent(json, Encoding.UTF8, "application/json")
+
+            Dim response As HttpResponseMessage = Await httpClient.PostAsync(apiUrl, content)
+            Dim responseBody As String = Await response.Content.ReadAsStringAsync()
+
+            Console.WriteLine(responseBody)
+        End Using
+    End Function
+
+    Sub Main()
+        SendSms().Wait()
+    End Sub
+End Module

--- a/windev/send_single_message.wl
+++ b/windev/send_single_message.wl
@@ -1,10 +1,26 @@
 requete est une restRequête
 
-requete.URL="<REPLACE_WITH_PROD_URL>/messages/send?from=SOSSO&to=2250000000000&content=Hello+API%21&token=<REPLACE_WITH_YOUR_API_KEY>&dlrUrl=https%3A%2F%2Fmydomain.com%3A4444%2Fdlr&dlrMethod=GET&customData=customData&sendAt=2023-02-13T21%3A40%3A00.000Z"
+requete.Méthode = restMéthodePOST
+requete.URL = "<REPLACE_WITH_PROD_URL>/v1/messages/send"
+requete.AjouteEnTête("Authorization", "Bearer <REPLACE_WITH_YOUR_API_KEY>")
+requete.AjouteEnTête("Content-Type", "application/json")
+
+corpsJSON est une chaîne = [
+    "from": "SOSSO",
+    "to": "2250000000000",
+    "content": "Hello API!",
+    "dlrUrl": "https://mydomain.com:4444/dlr",
+    "dlrMethod": "GET",
+    "customData": "customData",
+    "sendAt": "2023-02-13T21:40:00.000Z"
+]
+
+requete.AjouteCorps(corpsJSON, restFormatJSON)
+
 requeteReponse est une restRéponse = RESTEnvoie(requete)
 
 SI ErreurDétectée ALORS
-	ErreurInfo(errComplet)
+    ErreurInfo(errComplet)
 SINON
-	Info(requeteReponse.Contenu)
+    Info(requeteReponse.Contenu)
 FIN


### PR DESCRIPTION
### **Description:**

This PR modernizes our SMS sending API implementation by:

**Changes**
✅ Changed HTTP method from GET to POST

✅ Moved all parameters to JSON request body

✅ Added proper Authorization: Bearer header

✅ Set Content-Type: application/json

✅ Removed URL-encoded parameters

**Why This Improvement Matters**
Security: No longer exposes API token in URL

Best Practices: Aligns with REST standards for resource creation

Maintainability: Cleaner request structure

Scalability: Better support for complex requests